### PR TITLE
Replace initLine() method with repeatable setViewType() and added @IntDef annotation for LineType

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
             android:name="com.github.vipulasri.timelineview.sample.MainActivity"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.0-alpha07'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
 
@@ -27,7 +27,7 @@ task clean(type: Delete) {
 
 ext {
     compileSdkVersion = 26
-    buildToolsVersion = "26.0.2"
+    buildToolsVersion = "27.0.2"
     minSdkVersion = 14
     targetSdkVersion = 26
     supportLibrary = "26.1.0"

--- a/timelineview/build.gradle
+++ b/timelineview/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:support-annotations:26.1.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/timelineview/src/main/java/com/github/vipulasri/timelineview/LineType.java
+++ b/timelineview/src/main/java/com/github/vipulasri/timelineview/LineType.java
@@ -1,5 +1,10 @@
 package com.github.vipulasri.timelineview;
 
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Created by HP-HP on 05-12-2015.
  */
@@ -8,4 +13,15 @@ public class LineType {
     public static final int BEGIN = 1;
     public static final int END = 2;
     public static final int ONLYONE = 3;
+
+    @IntDef(flag=true, value={
+        LineType.NORMAL,
+        LineType.BEGIN,
+        LineType.END,
+        LineType.ONLYONE
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface LineTypeOptions {}
+
 }
+

--- a/timelineview/src/main/java/com/github/vipulasri/timelineview/TimelineView.java
+++ b/timelineview/src/main/java/com/github/vipulasri/timelineview/TimelineView.java
@@ -26,6 +26,7 @@ public class TimelineView extends View {
 
     private Rect mBounds;
     private Context mContext;
+    private int mActiveViewType = LineType.ONLYONE;
 
     public TimelineView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -140,11 +141,11 @@ public class TimelineView extends View {
             mMarker.draw(canvas);
         }
 
-        if(mStartLine != null) {
+        if(mStartLine != null && (mActiveViewType == LineType.NORMAL || mActiveViewType == LineType.END)) {
             mStartLine.draw(canvas);
         }
 
-        if(mEndLine != null) {
+        if(mEndLine != null&& (mActiveViewType == LineType.NORMAL || mActiveViewType == LineType.BEGIN)) {
             mEndLine.draw(canvas);
         }
     }
@@ -245,9 +246,12 @@ public class TimelineView extends View {
     /**
      * Init line.
      *
+     * This operation is permanent, you can use it just once.
+     *
      * @param viewType the view type
+     * @deprecated Use {@link #setViewType(int)}
      */
-    public void initLine(int viewType) {
+    public void initLine(@LineType.LineTypeOptions int viewType) {
         if(viewType == LineType.BEGIN) {
             setStartLine(null);
         } else if(viewType == LineType.END) {
@@ -257,6 +261,13 @@ public class TimelineView extends View {
             setEndLine(null);
         }
         initDrawable();
+    }
+
+    /**
+     * Change current render mode.
+     */
+    public void setViewType(@LineType.LineTypeOptions int viewType) {
+        mActiveViewType = viewType;
     }
 
     /**


### PR DESCRIPTION
I create pull request to solve https://github.com/vipulasri/Timeline-View/issues/20

This is only minimal necessary change to allows use this library without creating special viewType for all view states which is extremely complicated when you already have multiple viewTypes inside of RecyclerView. Create multiple views for every state doesn't make sense because onDraw() is still called for every instance when the view is rendered on screen. There is currently no cache to preserve its state.

So I just wanted to know your opinion. I'm using own fork and I'm happy with it, but maybe it can be useful for someone else.
