### PR TITLE
fix: avoid invalidating when drawing

### DIFF
--- a/timelineview/src/main/java/com/github/vipulasri/timelineview/TimelineView.java
+++ b/timelineview/src/main/java/com/github/vipulasri/timelineview/TimelineView.java
@@ -260,13 +260,11 @@ public class TimelineView extends View {
 
         if(mDrawStartLine) {
             mLinePaint.setColor(mStartLineColor);
-            invalidate();
             canvas.drawLine(mStartLineStartX, mStartLineStartY, mStartLineStopX, mStartLineStopY, mLinePaint);
         }
 
         if(mDrawEndLine) {
             mLinePaint.setColor(mEndLineColor);
-            invalidate();
             canvas.drawLine(mEndLineStartX, mEndLineStartY, mEndLineStopX, mEndLineStopY, mLinePaint);
         }
     }
@@ -496,12 +494,10 @@ public class TimelineView extends View {
 
     private void showStartLine(boolean show) {
         mDrawStartLine = show;
-        initTimeline();
     }
 
     private void showEndLine(boolean show) {
         mDrawEndLine = show;
-        initTimeline();
     }
 
     /**


### PR DESCRIPTION
# Description #
Currently in `onDraw()`, the view is sometimes invalidated. This means it will be infinitely redrawn.  You can see the behavior by enabling the "Show screen updates" setting in the Android debug settings.

Attached is two videos, the current 1.1.2 version that does infinite redraw, and the proposed fix that don't redraw unless needed.
[redraw-issue.zip](https://github.com/vipulasri/Timeline-View/files/3940821/redraw-issue.zip)

It result in poor performance.

Another side effect is that our instrumented tests will wait for the render thread to finish, and that will never happen, so tests are ending in a timeout.

I also removed two unneeded calls to `initTimeline()` from `showStartLine()` and `showEndLine()` since they are private and only called by `initLine()` that will call `initTimeline()` itself.

Thanks for sharing your work on this library.
