### PR TITLE
Remove allowBackup, supportsRtl and label from AndroidManifest

### DIFF
--- a/timelineview/src/main/AndroidManifest.xml
+++ b/timelineview/src/main/AndroidManifest.xml
@@ -1,11 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.vipulasri.timelineview">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest package="com.github.vipulasri.timelineview"/>

--- a/timelineview/src/main/res/values/strings.xml
+++ b/timelineview/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">TimeLine View</string>
-</resources>


### PR DESCRIPTION
fixes https://github.com/vipulasri/Timeline-View/issues/71

Those properties can cause conflicts when merging the app and the library manifests.

```
Manifest merger failed :  Attribute application@allowBackup value=(false) from AndroidManifest.xml:28:9-36
is also present at [com.github.vipulasri:timelineview:1.1.4] AndroidManifest.xml:12:9-35 value=(true).
Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:26:5-155:19 to override.
```

```
Manifest merger failed : Attribute application@supportsRtl value=(false) from AndroidManifest.xml:32:9-36
is also present at [com.github.vipulasri:timelineview:1.1.4] AndroidManifest.xml:14:9-35 value=(true).
Suggestion: add 'tools:replace="android:supportsRtl"' to <application> element at AndroidManifest.xml:26:5-157:19 to override.
```